### PR TITLE
Fixed joblib import issue

### DIFF
--- a/gcforest/common_utils.py
+++ b/gcforest/common_utils.py
@@ -1,6 +1,6 @@
 import numpy as np
 from sklearn.model_selection import KFold, StratifiedKFold
-from joblib
+import joblib
 import os
 import shutil
 

--- a/gcforest/common_utils.py
+++ b/gcforest/common_utils.py
@@ -1,6 +1,6 @@
 import numpy as np
 from sklearn.model_selection import KFold, StratifiedKFold
-from sklearn.externals import joblib
+from joblib
 import os
 import shutil
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,6 @@
 # Note: might work with versions, prior to these (these were used when developing this implementation)
 numpy  # developed with 1.14.3
 scikit-learn  # developed with 0.19.1
+
+#added later
+joblib # added since job-lib was removed from scikit-learn.externals


### PR DESCRIPTION
While trying to use the code, I found that it had a minor issue with one of the dependencies, joblib. it has been removed from scikit-learn and made into its own package. So, to keep the library updated, and in 'plug-and-play' shape, appropriate changes have been made.
